### PR TITLE
ci: update upload-pages-artifact action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: dist
   deploy:


### PR DESCRIPTION
## Summary
- use actions/upload-pages-artifact@v3 for Pages deployment
- confirm no usage of deprecated actions/upload-artifact@v3

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm ci`
- `npm run build` *(fails: Rollup failed to resolve import "/resume-web/assets/index.js" from "/workspace/resume-web/index.html")*

------
https://chatgpt.com/codex/tasks/task_e_6899d87592fc832e8f2f37ec8ab43438